### PR TITLE
Support Arc for multi-thread cases

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,6 @@
 name: Test
 
-on:
-  push: {}
-  pull_request: {}
+on: [push, pull_request]
 
 jobs:
   test:
@@ -10,17 +8,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            override: true
-            components: rustfmt, clippy
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Check format
         run: cargo fmt --all -- --check
-      
+
       - name: Check clippy
         run: cargo clippy -- -D warnings
-      
+
       - name: Run tests
         run: cargo test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
+            components: rustfmt, clippy
+
+      - name: Check format
+        run: cargo fmt --all -- --check
+      
+      - name: Check clippy
+        run: cargo clippy -- -D warnings
+      
+      - name: Run tests
+        run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "im_interval_tree"
 description = "An immutable data structure for storing and querying a collection of intervals"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Jennifer Blight <jgblight@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 repository = "https://github.com/jgblight/im_interval_tree"
 categories = ["data-structures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,8 @@ license = "MIT"
 repository = "https://github.com/jgblight/im_interval_tree"
 categories = ["data-structures"]
 
+[features]
+arc = []
+
 [dev-dependencies]
 quickcheck = { git = "https://github.com/BurntSushi/quickcheck", rev = "71d743a" }

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -7,7 +7,8 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::ops::Bound;
 use std::ops::Bound::*;
-use std::rc::Rc;
+
+use crate::shared::Shared;
 
 pub fn low_bound_cmp<T: Ord>(a: &Bound<T>, b: &Bound<T>) -> Ordering {
     match (a, b) {
@@ -33,7 +34,10 @@ pub fn low_bound_cmp<T: Ord>(a: &Bound<T>, b: &Bound<T>) -> Ordering {
     }
 }
 
-pub fn low_bound_min<T: Ord + Clone>(a: &Rc<Bound<T>>, b: &Rc<Bound<T>>) -> Rc<Bound<T>> {
+pub fn low_bound_min<T: Ord + Clone>(
+    a: &Shared<Bound<T>>,
+    b: &Shared<Bound<T>>,
+) -> Shared<Bound<T>> {
     match low_bound_cmp(a, b) {
         Ordering::Less => a.clone(),
         _ => b.clone(),
@@ -64,7 +68,10 @@ pub fn high_bound_cmp<T: Ord + Clone>(a: &Bound<T>, b: &Bound<T>) -> Ordering {
     }
 }
 
-pub fn high_bound_max<T: Ord + Clone>(a: &Rc<Bound<T>>, b: &Rc<Bound<T>>) -> Rc<Bound<T>> {
+pub fn high_bound_max<T: Ord + Clone>(
+    a: &Shared<Bound<T>>,
+    b: &Shared<Bound<T>>,
+) -> Shared<Bound<T>> {
     match high_bound_cmp(a, b) {
         Ordering::Less => b.clone(),
         _ => a.clone(),
@@ -74,8 +81,8 @@ pub fn high_bound_max<T: Ord + Clone>(a: &Rc<Bound<T>>, b: &Rc<Bound<T>>) -> Rc<
 /// A data structure for representing intervals
 #[derive(Debug, Clone)]
 pub struct Interval<T: Ord + Clone> {
-    pub(crate) low: Rc<Bound<T>>,
-    pub(crate) high: Rc<Bound<T>>,
+    pub(crate) low: Shared<Bound<T>>,
+    pub(crate) high: Shared<Bound<T>>,
 }
 
 impl<T: Ord + Clone> Interval<T> {
@@ -89,8 +96,8 @@ impl<T: Ord + Clone> Interval<T> {
     /// ```
     pub fn new(low: Bound<T>, high: Bound<T>) -> Interval<T> {
         Interval {
-            low: Rc::new(low),
-            high: Rc::new(high),
+            low: Shared::new(low),
+            high: Shared::new(high),
         }
     }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,0 +1,5 @@
+#[cfg(not(feature = "arc"))]
+pub type Shared<T> = std::rc::Rc<T>;
+
+#[cfg(feature = "arc")]
+pub type Shared<T> = std::sync::Arc<T>;


### PR DESCRIPTION
This PR implements the issue #3 and requires the PR #2 to be merged first.

By default it uses `Rc` as before, but if the feature flag `arc` is specified, it will use `Arc`, which will make the data structure `Send`.

I'm open to change names as requested by the author ;-) 